### PR TITLE
Fix workflow step name quoting in cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -60,6 +60,6 @@ jobs:
         with:
           path: ./dist
 
-      - name: CD: Deploy to GitHub Pages
+      - name: "CD: Deploy to GitHub Pages"
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- quote the deployment step name string so the cd workflow parses without syntax errors
- ensure the GitHub Pages deploy step remains unchanged except for the name text

## Testing
- Not run (not requested)