### PR TITLE
Add thunks, selectors, and tests for posts and subreddits

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -60,6 +60,6 @@ jobs:
         with:
           path: ./dist
 
-      - name: CD: Deploy to GitHub Pages
+      - name: "CD: Deploy to GitHub Pages"
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,8 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Test
+        run: npm test
+
       - name: Build
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Reddit Lite is a small React + Redux app that lets users browse posts, open comments, and use a responsive Reddit-style UI.
 
+[![CI](https://github.com/ocastorena/reddit-lite/actions/workflows/ci.yml/badge.svg)](https://github.com/ocastorena/reddit-lite/actions/workflows/ci.yml)
+
 ## Tech Stack
 
 - React
@@ -22,8 +24,20 @@ Open `http://localhost:5173`.
 
 - `npm run dev` - Start local dev server
 - `npm run lint` - Run ESLint
+- `npm run test` - Run reducer/selector unit tests
 - `npm run build` - Create production build
 - `npm run preview` - Preview production build locally
+
+## Testing
+
+```sh
+npm test
+```
+
+Current tests cover Redux reducers and selectors for:
+
+- `postsFeed`
+- `popularSubreddits`
 
 ## CI/CD
 
@@ -31,7 +45,7 @@ This repo includes two GitHub Actions workflows:
 
 - `/.github/workflows/ci.yml`
   - Runs on pull requests and pushes to `main`
-  - Executes `npm ci`, `npm run lint`, and `npm run build`
+  - Executes `npm ci`, `npm run lint`, `npm test`, and `npm run build`
 - `/.github/workflows/cd.yml`
   - Runs after `CI` succeeds on `main` (or manually via workflow dispatch)
   - Builds and deploys `dist/` to GitHub Pages

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "test": "node --test src/**/*.test.js",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,7 +1,7 @@
 import Header from "../components/Navbar/Header";
 import PostsFeed from "../features/postsFeed/PostsFeed";
-import Subreddits from "../features/subreddits/Subreddits";
-import Sidebar from "../components/Sidebar/Sidebar";
+import SubredditsList from "../features/subreddits/components/SubredditsList";
+import SubredditDetails from "../features/subreddits/components/SubredditDetails";
 
 function App() {
   return (
@@ -9,13 +9,13 @@ function App() {
       <Header />
       <main className="grid grid-cols-4 gap-4 px-4 pt-20 pb-20 w-full h-screen">
         <aside className="hidden sm:block col-span-1 bg-zinc-900 rounded-lg p-4 h-fit sm:min-w-46">
-          <Sidebar />
+          <SubredditDetails />
         </aside>
         <section className="col-span-4 sm:col-span-2 flex flex-col items-center rounded-lg w-full h-full overflow-y-auto scrollbar-hide">
           <PostsFeed />
         </section>
         <aside className="hidden sm:flex col-span-1 flex-col overflow-y-auto rounded-lg bg-zinc-900 sm:min-w-46">
-          <Subreddits />
+          <SubredditsList />
         </aside>
       </main>
       {/* <footer className="bg-amber-400 w-full h-16 sticky bottom-0"></footer> */}

--- a/src/components/Navbar/Header.jsx
+++ b/src/components/Navbar/Header.jsx
@@ -1,9 +1,9 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useDispatch } from "react-redux";
 import { setFilteredPosts } from "../../features/postsFeed/postsFeedSlice";
 // Components
-import Sidebar from "../Sidebar/Sidebar";
-import Subreddits from "../../features/subreddits/Subreddits";
+import SubredditDetails from "../../features/subreddits/components/SubredditDetails";
+import SubredditsList from "../../features/subreddits/components/SubredditsList";
 // SVGs as components
 import MenuIcon from "../../assets/hamburger-menu.svg?react";
 // SVGs as images
@@ -58,8 +58,8 @@ const Navbar = () => {
       </button>
       {isMenuOpen && (
         <div className="sm:hidden bg-zinc-900 w-full p-4 mt-4 col-span-2 overflow-y-auto scrollbar-hide">
-          <Sidebar />
-          <Subreddits />
+          <SubredditDetails />
+          <SubredditsList />
         </div>
       )}
     </header>

--- a/src/features/postsFeed/PostsFeed.jsx
+++ b/src/features/postsFeed/PostsFeed.jsx
@@ -1,12 +1,9 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import Card from "../../components/Card/Card";
-import {
-  loadAllPosts,
-  selectAllPosts,
-  isLoadingPostsFeed,
-} from "./postsFeedSlice";
-import { selectCurrentSubreddit } from "../subreddits/subredditsSlice";
+import Card from "./components/Card";
+import { loadAllPosts } from "./postsFeedThunks";
+import { isLoadingPostsFeed, selectAllPosts } from "./postsFeedSelectors";
+import { selectCurrentSubreddit } from "../subreddits/subredditsSelectors";
 
 const PostsFeed = () => {
   const dispatch = useDispatch();
@@ -18,7 +15,7 @@ const PostsFeed = () => {
     if (Object.keys(currentSubreddit).length > 0) {
       dispatch(loadAllPosts(currentSubreddit.display_name));
     }
-  }, [currentSubreddit]);
+  }, [dispatch, currentSubreddit]);
 
   if (isLoading || Object.keys(currentSubreddit).length === 0) {
     return (

--- a/src/features/postsFeed/components/Card.jsx
+++ b/src/features/postsFeed/components/Card.jsx
@@ -1,9 +1,11 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import PropTypes from "prop-types";
 import Comments from "./Comments";
-import CommentIcon from "../../assets/comments.svg?react";
-import UpVoteIcon from "../../assets/up.svg?react";
-import DownVoteIcon from "../../assets/down.svg?react";
-import { formatNumber } from "../../utils/formatNumber";
+import CommentIcon from "../../../assets/comments.svg?react";
+import UpVoteIcon from "../../../assets/up.svg?react";
+import DownVoteIcon from "../../../assets/down.svg?react";
+import { formatNumber } from "../../../utils/formatNumber";
+import { getRelativeTime } from "../../../utils/date/getRelativeTime";
 
 const Card = ({ post, subreddit }) => {
   const [showComments, setShowComments] = useState(false);
@@ -13,30 +15,6 @@ const Card = ({ post, subreddit }) => {
   const imageUrl = post.preview?.images[0]?.source?.url.replace(/&amp;/g, "&");
   const thumbnailUrl =
     post.thumbnail && post.thumbnail.startsWith("http") ? post.thumbnail : null;
-
-  const getRelativeTime = (timestamp) => {
-    const now = new Date();
-    const postDate = new Date(timestamp * 1000);
-    const secondsAgo = Math.floor((now - postDate) / 1000);
-
-    const intervals = {
-      year: 31536000,
-      month: 2592000,
-      week: 604800,
-      day: 86400,
-      hour: 3600,
-      minute: 60,
-      second: 1,
-    };
-
-    for (const [unit, secondsInUnit] of Object.entries(intervals)) {
-      const interval = Math.floor(secondsAgo / secondsInUnit);
-      if (interval >= 1) {
-        return `${interval} ${unit}${interval !== 1 ? "s" : ""} ago`;
-      }
-    }
-    return "just now";
-  };
 
   const postTime = getRelativeTime(post.created_utc);
 
@@ -164,6 +142,33 @@ const Card = ({ post, subreddit }) => {
       )}
     </article>
   );
+};
+
+Card.propTypes = {
+  post: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    author: PropTypes.string,
+    created_utc: PropTypes.number,
+    downs: PropTypes.number,
+    num_comments: PropTypes.number,
+    selftext: PropTypes.string,
+    thumbnail: PropTypes.string,
+    title: PropTypes.string,
+    ups: PropTypes.number,
+    url: PropTypes.string,
+    preview: PropTypes.shape({
+      images: PropTypes.arrayOf(
+        PropTypes.shape({
+          source: PropTypes.shape({
+            url: PropTypes.string,
+          }),
+        })
+      ),
+    }),
+  }).isRequired,
+  subreddit: PropTypes.shape({
+    display_name: PropTypes.string,
+  }).isRequired,
 };
 
 export default Card;

--- a/src/features/postsFeed/components/Comments.jsx
+++ b/src/features/postsFeed/components/Comments.jsx
@@ -1,10 +1,9 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
+import PropTypes from "prop-types";
 import { useDispatch, useSelector } from "react-redux";
-import {
-  selectComments,
-  loadComments,
-  isLoadingComments,
-} from "../../features/postsFeed/postsFeedSlice";
+import { loadComments } from "../postsFeedThunks";
+import { isLoadingComments, selectComments } from "../postsFeedSelectors";
+import { getRelativeTime } from "../../../utils/date/getRelativeTime";
 
 const Comments = ({ subredditName, postId }) => {
   const dispatch = useDispatch();
@@ -13,31 +12,7 @@ const Comments = ({ subredditName, postId }) => {
 
   useEffect(() => {
     dispatch(loadComments({ subredditName, postId }));
-  }, [dispatch]);
-
-  const getRelativeTime = (timestamp) => {
-    const now = new Date();
-    const postDate = new Date(timestamp * 1000);
-    const secondsAgo = Math.floor((now - postDate) / 1000);
-
-    const intervals = {
-      year: 31536000,
-      month: 2592000,
-      week: 604800,
-      day: 86400,
-      hour: 3600,
-      minute: 60,
-      second: 1,
-    };
-
-    for (const [unit, secondsInUnit] of Object.entries(intervals)) {
-      const interval = Math.floor(secondsAgo / secondsInUnit);
-      if (interval >= 1) {
-        return `${interval} ${unit}${interval !== 1 ? "s" : ""} ago`;
-      }
-    }
-    return "just now";
-  };
+  }, [dispatch, subredditName, postId]);
 
   return (
     <section>
@@ -70,6 +45,11 @@ const Comments = ({ subredditName, postId }) => {
       )}
     </section>
   );
+};
+
+Comments.propTypes = {
+  subredditName: PropTypes.string.isRequired,
+  postId: PropTypes.string.isRequired,
 };
 
 export default Comments;

--- a/src/features/postsFeed/postsFeedSelectors.js
+++ b/src/features/postsFeed/postsFeedSelectors.js
@@ -1,0 +1,5 @@
+export const selectAllPosts = (state) => state.postsFeed.posts.filteredItems;
+export const isLoadingPostsFeed = (state) => state.postsFeed.posts.isLoading;
+
+export const selectComments = (state) => state.postsFeed.comments.items;
+export const isLoadingComments = (state) => state.postsFeed.comments.isLoading;

--- a/src/features/postsFeed/postsFeedSlice.js
+++ b/src/features/postsFeed/postsFeedSlice.js
@@ -1,50 +1,24 @@
-import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import { fetchPosts, fetchComments } from "../../utils/api";
-
-export const loadAllPosts = createAsyncThunk(
-  "postsFeed/loadAllPosts",
-  async (subreddit, thunkAPI) => {
-    try {
-      const posts = await fetchPosts(subreddit);
-      return posts;
-    } catch (error) {
-      return thunkAPI.rejectWithValue(error.message);
-    }
-  }
-);
-
-export const loadComments = createAsyncThunk(
-  "postsFeed/loadComments",
-  async ({ subredditName, postId }, thunkAPI) => {
-    try {
-      const comments = await fetchComments(subredditName, postId);
-      return comments;
-    } catch (error) {
-      return thunkAPI.rejectWithValue(error.message);
-    }
-  }
-);
+import { createSlice } from "@reduxjs/toolkit";
+import { loadAllPosts, loadComments } from "./postsFeedThunks.js";
 
 const postsFeedSlice = createSlice({
   name: "postsFeed",
   initialState: {
     posts: {
-      posts: [],
-      filteredPosts: [],
-      isLoadingPostsFeed: false,
+      items: [],
+      filteredItems: [],
+      isLoading: false,
       hasError: false,
     },
     comments: {
-      comments: {
-        comments: [],
-        isLoadingComments: false,
-        hasError: false,
-      },
+      items: [],
+      isLoading: false,
+      hasError: false,
     },
   },
   reducers: {
     setFilteredPosts: (state, action) => {
-      state.posts.filteredPosts = state.posts.posts.filter((post) =>
+      state.posts.filteredItems = state.posts.items.filter((post) =>
         post.title.toLowerCase().includes(action.payload)
       );
     },
@@ -52,41 +26,33 @@ const postsFeedSlice = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(loadAllPosts.pending, (state) => {
-        state.posts.isLoadingPostsFeed = true;
+        state.posts.isLoading = true;
         state.posts.hasError = false;
       })
       .addCase(loadAllPosts.fulfilled, (state, action) => {
-        state.posts.isLoadingPostsFeed = false;
-        state.posts.posts = action.payload;
-        state.posts.filteredPosts = action.payload;
+        state.posts.isLoading = false;
+        state.posts.items = action.payload;
+        state.posts.filteredItems = action.payload;
       })
       .addCase(loadAllPosts.rejected, (state) => {
-        state.posts.isLoadingPostsFeed = false;
+        state.posts.isLoading = false;
         state.posts.hasError = true;
       })
       .addCase(loadComments.pending, (state) => {
-        state.comments.isLoadingComments = true;
+        state.comments.isLoading = true;
         state.comments.hasError = false;
       })
       .addCase(loadComments.fulfilled, (state, action) => {
-        state.comments.isLoadingComments = false;
-        state.comments.comments = action.payload;
+        state.comments.isLoading = false;
+        state.comments.items = action.payload;
       })
       .addCase(loadComments.rejected, (state) => {
-        state.comments.isLoadingComments = false;
+        state.comments.isLoading = false;
         state.comments.hasError = true;
       });
   },
 });
 
 export const { setFilteredPosts } = postsFeedSlice.actions;
-
-export const selectAllPosts = (state) => state.postsFeed.posts.filteredPosts;
-export const isLoadingPostsFeed = (state) =>
-  state.postsFeed.posts.isLoadingPostsFeed;
-
-export const selectComments = (state) => state.postsFeed.comments.comments;
-export const isLoadingComments = (state) =>
-  state.postsFeed.comments.isLoadingComments;
 
 export default postsFeedSlice.reducer;

--- a/src/features/postsFeed/postsFeedSlice.test.js
+++ b/src/features/postsFeed/postsFeedSlice.test.js
@@ -1,0 +1,109 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import reducer, { setFilteredPosts } from "./postsFeedSlice.js";
+import { loadAllPosts, loadComments } from "./postsFeedThunks.js";
+import {
+  isLoadingComments,
+  isLoadingPostsFeed,
+  selectAllPosts,
+  selectComments,
+} from "./postsFeedSelectors.js";
+
+test("returns the initial state", () => {
+  const state = reducer(undefined, { type: "unknown" });
+
+  assert.deepStrictEqual(state, {
+    posts: {
+      items: [],
+      filteredItems: [],
+      isLoading: false,
+      hasError: false,
+    },
+    comments: {
+      items: [],
+      isLoading: false,
+      hasError: false,
+    },
+  });
+});
+
+test("setFilteredPosts filters by title", () => {
+  const initialState = {
+    posts: {
+      items: [
+        { id: "1", title: "React Hooks Guide" },
+        { id: "2", title: "Rust ownership tips" },
+      ],
+      filteredItems: [],
+      isLoading: false,
+      hasError: false,
+    },
+    comments: {
+      items: [],
+      isLoading: false,
+      hasError: false,
+    },
+  };
+
+  const state = reducer(initialState, setFilteredPosts("react"));
+  assert.equal(state.posts.filteredItems.length, 1);
+  assert.equal(state.posts.filteredItems[0].id, "1");
+});
+
+test("loadAllPosts lifecycle updates posts state", () => {
+  const pendingState = reducer(undefined, loadAllPosts.pending("req1", "reactjs"));
+  assert.equal(pendingState.posts.isLoading, true);
+  assert.equal(pendingState.posts.hasError, false);
+
+  const payload = [{ id: "p1", title: "Post 1" }];
+  const fulfilledState = reducer(
+    pendingState,
+    loadAllPosts.fulfilled(payload, "req1", "reactjs")
+  );
+  assert.equal(fulfilledState.posts.isLoading, false);
+  assert.deepStrictEqual(fulfilledState.posts.items, payload);
+  assert.deepStrictEqual(fulfilledState.posts.filteredItems, payload);
+
+  const rejectedState = reducer(fulfilledState, loadAllPosts.rejected(null, "req2", "reactjs"));
+  assert.equal(rejectedState.posts.isLoading, false);
+  assert.equal(rejectedState.posts.hasError, true);
+});
+
+test("loadComments lifecycle updates comments state", () => {
+  const arg = { subredditName: "reactjs", postId: "abc" };
+  const pendingState = reducer(undefined, loadComments.pending("req1", arg));
+  assert.equal(pendingState.comments.isLoading, true);
+  assert.equal(pendingState.comments.hasError, false);
+
+  const payload = [{ id: "c1", body: "Nice post" }];
+  const fulfilledState = reducer(pendingState, loadComments.fulfilled(payload, "req1", arg));
+  assert.equal(fulfilledState.comments.isLoading, false);
+  assert.deepStrictEqual(fulfilledState.comments.items, payload);
+
+  const rejectedState = reducer(fulfilledState, loadComments.rejected(null, "req2", arg));
+  assert.equal(rejectedState.comments.isLoading, false);
+  assert.equal(rejectedState.comments.hasError, true);
+});
+
+test("selectors read normalized postsFeed state", () => {
+  const state = {
+    postsFeed: {
+      posts: {
+        items: [{ id: "p1" }],
+        filteredItems: [{ id: "p2" }],
+        isLoading: true,
+        hasError: false,
+      },
+      comments: {
+        items: [{ id: "c1" }],
+        isLoading: false,
+        hasError: false,
+      },
+    },
+  };
+
+  assert.deepStrictEqual(selectAllPosts(state), [{ id: "p2" }]);
+  assert.equal(isLoadingPostsFeed(state), true);
+  assert.deepStrictEqual(selectComments(state), [{ id: "c1" }]);
+  assert.equal(isLoadingComments(state), false);
+});

--- a/src/features/postsFeed/postsFeedThunks.js
+++ b/src/features/postsFeed/postsFeedThunks.js
@@ -1,0 +1,26 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import { fetchComments, fetchPosts } from "../../utils/api.js";
+
+export const loadAllPosts = createAsyncThunk(
+  "postsFeed/loadAllPosts",
+  async (subreddit, thunkAPI) => {
+    try {
+      const posts = await fetchPosts(subreddit);
+      return posts;
+    } catch (error) {
+      return thunkAPI.rejectWithValue(error.message);
+    }
+  }
+);
+
+export const loadComments = createAsyncThunk(
+  "postsFeed/loadComments",
+  async ({ subredditName, postId }, thunkAPI) => {
+    try {
+      const comments = await fetchComments(subredditName, postId);
+      return comments;
+    } catch (error) {
+      return thunkAPI.rejectWithValue(error.message);
+    }
+  }
+);

--- a/src/features/subreddits/components/SubredditDetails.jsx
+++ b/src/features/subreddits/components/SubredditDetails.jsx
@@ -1,14 +1,14 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { loadCurrentSubredditDetails } from "../subredditsThunks";
 import {
-  loadCurrentSubredditDetails,
   selectCurrentSubreddit,
   selectSubredditDetails,
-} from "../../features/subreddits/subredditsSlice";
-import { formatNumber } from "../../utils/formatNumber";
-import defaultSubredditUrl from "../../assets/letter-r.png";
+} from "../subredditsSelectors";
+import { formatNumber } from "../../../utils/formatNumber";
+import defaultSubredditUrl from "../../../assets/letter-r.png";
 
-const Sidebar = () => {
+const SubredditDetails = () => {
   const subreddit = useSelector(selectCurrentSubreddit);
   const subredditDetails = useSelector(selectSubredditDetails);
   const dispatch = useDispatch();
@@ -17,7 +17,7 @@ const Sidebar = () => {
     if (Object.keys(subreddit).length > 0) {
       dispatch(loadCurrentSubredditDetails(subreddit.display_name));
     }
-  }, [subreddit]);
+  }, [dispatch, subreddit]);
 
   const formatDate = (timestamp) => {
     const date = new Date(timestamp * 1000);
@@ -84,4 +84,4 @@ const Sidebar = () => {
   );
 };
 
-export default Sidebar;
+export default SubredditDetails;

--- a/src/features/subreddits/components/SubredditsList.jsx
+++ b/src/features/subreddits/components/SubredditsList.jsx
@@ -1,15 +1,15 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { setCurrentSubreddit } from "../subredditsSlice";
+import { loadSubreddits } from "../subredditsThunks";
 import {
-  loadSubreddits,
-  selectAllSubreddits,
   isLoadingSubreddits,
-  setCurrentSubreddit,
+  selectAllSubreddits,
   selectCurrentSubreddit,
-} from "./subredditsSlice";
-import defaultSubredditUrl from "../../assets/letter-r.png";
+} from "../subredditsSelectors";
+import defaultSubredditUrl from "../../../assets/letter-r.png";
 
-const Subreddits = () => {
+const SubredditsList = () => {
   const dispatch = useDispatch();
   const subreddits = useSelector(selectAllSubreddits);
   const isLoading = useSelector(isLoadingSubreddits);
@@ -19,7 +19,7 @@ const Subreddits = () => {
     if (Object.keys(currentSubreddit).length === 0) {
       dispatch(loadSubreddits());
     }
-  }, []);
+  }, [dispatch, currentSubreddit]);
 
   return (
     <>
@@ -58,4 +58,4 @@ const Subreddits = () => {
   );
 };
 
-export default Subreddits;
+export default SubredditsList;

--- a/src/features/subreddits/subredditsSelectors.js
+++ b/src/features/subreddits/subredditsSelectors.js
@@ -1,0 +1,11 @@
+export const selectAllSubreddits = (state) =>
+  state.popularSubreddits.subreddits;
+
+export const isLoadingSubreddits = (state) =>
+  state.popularSubreddits.isLoadingSubreddits;
+
+export const selectCurrentSubreddit = (state) =>
+  state.popularSubreddits.currentSubreddit;
+
+export const selectSubredditDetails = (state) =>
+  state.popularSubreddits.subredditDetails;

--- a/src/features/subreddits/subredditsSlice.js
+++ b/src/features/subreddits/subredditsSlice.js
@@ -1,29 +1,8 @@
-import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
-import { fetchPopularSubreddits, fetchSubredditDetails } from "../../utils/api";
-
-export const loadSubreddits = createAsyncThunk(
-  "popularSubreddits/loadSubreddits",
-  async (thunkAPI) => {
-    try {
-      const subreddits = await fetchPopularSubreddits();
-      return subreddits;
-    } catch (error) {
-      return thunkAPI.rejectWithValue(error.message);
-    }
-  }
-);
-
-export const loadCurrentSubredditDetails = createAsyncThunk(
-  "popularSubreddits/loadCurrentSubredditDetails",
-  async (subredditName, thunkAPI) => {
-    try {
-      const subredditDetails = await fetchSubredditDetails(subredditName);
-      return subredditDetails;
-    } catch (error) {
-      return thunkAPI.rejectWithValue(error.message);
-    }
-  }
-);
+import { createSlice } from "@reduxjs/toolkit";
+import {
+  loadCurrentSubredditDetails,
+  loadSubreddits,
+} from "./subredditsThunks.js";
 
 const subredditsSlice = createSlice({
   name: "popularSubreddits",
@@ -73,17 +52,5 @@ const subredditsSlice = createSlice({
 });
 
 export const { setCurrentSubreddit } = subredditsSlice.actions;
-
-export const selectAllSubreddits = (state) =>
-  state.popularSubreddits.subreddits;
-
-export const isLoadingSubreddits = (state) =>
-  state.popularSubreddits.isLoadingSubreddits;
-
-export const selectCurrentSubreddit = (state) =>
-  state.popularSubreddits.currentSubreddit;
-
-export const selectSubredditDetails = (state) =>
-  state.popularSubreddits.subredditDetails;
 
 export default subredditsSlice.reducer;

--- a/src/features/subreddits/subredditsSlice.test.js
+++ b/src/features/subreddits/subredditsSlice.test.js
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import reducer, { setCurrentSubreddit } from "./subredditsSlice.js";
+import {
+  loadCurrentSubredditDetails,
+  loadSubreddits,
+} from "./subredditsThunks.js";
+import {
+  isLoadingSubreddits,
+  selectAllSubreddits,
+  selectCurrentSubreddit,
+  selectSubredditDetails,
+} from "./subredditsSelectors.js";
+
+test("returns the initial state", () => {
+  const state = reducer(undefined, { type: "unknown" });
+
+  assert.deepStrictEqual(state, {
+    currentSubreddit: {},
+    subreddits: [],
+    isLoadingSubreddits: false,
+    hasError: false,
+    subredditDetails: {},
+    isLoadingSubredditDetails: false,
+  });
+});
+
+test("setCurrentSubreddit updates selected subreddit", () => {
+  const subreddit = { id: "1", display_name: "reactjs" };
+  const state = reducer(undefined, setCurrentSubreddit(subreddit));
+  assert.deepStrictEqual(state.currentSubreddit, subreddit);
+});
+
+test("loadSubreddits lifecycle updates subreddit list state", () => {
+  const pendingState = reducer(undefined, loadSubreddits.pending("req1"));
+  assert.equal(pendingState.isLoadingSubreddits, true);
+  assert.equal(pendingState.hasError, false);
+
+  const payload = [{ id: "s1", display_name: "reactjs" }];
+  const fulfilledState = reducer(
+    pendingState,
+    loadSubreddits.fulfilled(payload, "req1")
+  );
+  assert.equal(fulfilledState.isLoadingSubreddits, false);
+  assert.equal(fulfilledState.hasError, false);
+  assert.deepStrictEqual(fulfilledState.subreddits, payload);
+  assert.deepStrictEqual(fulfilledState.currentSubreddit, payload[0]);
+
+  const rejectedState = reducer(fulfilledState, loadSubreddits.rejected(null, "req2"));
+  assert.equal(rejectedState.isLoadingSubreddits, false);
+  assert.equal(rejectedState.hasError, true);
+});
+
+test("loadCurrentSubredditDetails lifecycle updates details state", () => {
+  const pendingState = reducer(
+    undefined,
+    loadCurrentSubredditDetails.pending("req1", "reactjs")
+  );
+  assert.equal(pendingState.isLoadingSubredditDetails, true);
+  assert.equal(pendingState.hasError, false);
+
+  const payload = { display_name: "reactjs", subscribers: 1000 };
+  const fulfilledState = reducer(
+    pendingState,
+    loadCurrentSubredditDetails.fulfilled(payload, "req1", "reactjs")
+  );
+  assert.equal(fulfilledState.isLoadingSubredditDetails, false);
+  assert.equal(fulfilledState.hasError, false);
+  assert.deepStrictEqual(fulfilledState.subredditDetails, payload);
+
+  const rejectedState = reducer(
+    fulfilledState,
+    loadCurrentSubredditDetails.rejected(null, "req2", "reactjs")
+  );
+  assert.equal(rejectedState.isLoadingSubredditDetails, false);
+  assert.equal(rejectedState.hasError, true);
+});
+
+test("selectors read popularSubreddits state", () => {
+  const state = {
+    popularSubreddits: {
+      currentSubreddit: { id: "s2", display_name: "javascript" },
+      subreddits: [{ id: "s1", display_name: "reactjs" }],
+      isLoadingSubreddits: true,
+      hasError: false,
+      subredditDetails: { display_name: "javascript", subscribers: 42 },
+      isLoadingSubredditDetails: false,
+    },
+  };
+
+  assert.deepStrictEqual(selectAllSubreddits(state), [
+    { id: "s1", display_name: "reactjs" },
+  ]);
+  assert.equal(isLoadingSubreddits(state), true);
+  assert.deepStrictEqual(selectCurrentSubreddit(state), {
+    id: "s2",
+    display_name: "javascript",
+  });
+  assert.deepStrictEqual(selectSubredditDetails(state), {
+    display_name: "javascript",
+    subscribers: 42,
+  });
+});

--- a/src/features/subreddits/subredditsThunks.js
+++ b/src/features/subreddits/subredditsThunks.js
@@ -1,0 +1,29 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import {
+  fetchPopularSubreddits,
+  fetchSubredditDetails,
+} from "../../utils/api.js";
+
+export const loadSubreddits = createAsyncThunk(
+  "popularSubreddits/loadSubreddits",
+  async (thunkAPI) => {
+    try {
+      const subreddits = await fetchPopularSubreddits();
+      return subreddits;
+    } catch (error) {
+      return thunkAPI.rejectWithValue(error.message);
+    }
+  }
+);
+
+export const loadCurrentSubredditDetails = createAsyncThunk(
+  "popularSubreddits/loadCurrentSubredditDetails",
+  async (subredditName, thunkAPI) => {
+    try {
+      const subredditDetails = await fetchSubredditDetails(subredditName);
+      return subredditDetails;
+    } catch (error) {
+      return thunkAPI.rejectWithValue(error.message);
+    }
+  }
+);

--- a/src/utils/date/getRelativeTime.js
+++ b/src/utils/date/getRelativeTime.js
@@ -1,0 +1,24 @@
+export const getRelativeTime = (timestamp) => {
+  const now = new Date();
+  const date = new Date(timestamp * 1000);
+  const secondsAgo = Math.floor((now - date) / 1000);
+
+  const intervals = {
+    year: 31536000,
+    month: 2592000,
+    week: 604800,
+    day: 86400,
+    hour: 3600,
+    minute: 60,
+    second: 1,
+  };
+
+  for (const [unit, secondsInUnit] of Object.entries(intervals)) {
+    const interval = Math.floor(secondsAgo / secondsInUnit);
+    if (interval >= 1) {
+      return `${interval} ${unit}${interval !== 1 ? "s" : ""} ago`;
+    }
+  }
+
+  return "just now";
+};


### PR DESCRIPTION
## Summary
- normalize posts/subreddits slices by moving thunks, selectors, and dependent UI components into feature folders and wiring up the new selectors everywhere
- add shared utilities, prop types, and badge/README guidance for the new reducer/tests coverage
- expand CI to run unit tests via the new `npm test` script

## Testing
- Not run (not requested)