### PR TITLE
Fix test script glob usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "node --test src/**/*.test.js",
+    "test": "node --test",
     "lint": "eslint .",
     "preview": "vite preview"
   },


### PR DESCRIPTION
Summary
- update the npm test script to call `node --test` directly so it no longer looks for missing `src/**/*.test.js` files during CI

Testing
- Not run (not requested)